### PR TITLE
Fix stamp_fields utility function

### DIFF
--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -67,7 +67,9 @@ def stamp_fields(model):
     """
     Returns serialized description of model fields.
     """
-    stamp = str(sorted(f.deconstruct()[:2] for f in model._meta.fields))
+    stamp = str(sorted(
+        json.dumps(f.deconstruct(), sort_keys=True, default=obj_key)
+        for f in model._meta.fields))
     return md5hex(stamp)
 
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -67,7 +67,9 @@ def stamp_fields(model):
     """
     Returns serialized description of model fields.
     """
-    stamp = str(sorted((f.name, f.attname, f.db_column, f.__class__) for f in model._meta.fields))
+    stamp = str(sorted(
+        (f.name, f.attname, f.db_column, f.__class__.__name__)
+        for f in model._meta.fields))
     return md5hex(stamp)
 
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -67,7 +67,7 @@ def stamp_fields(model):
     """
     Returns serialized description of model fields.
     """
-    stamp = str(sorted(f.deconstruct() for f in model._meta.fields))
+    stamp = str(sorted(f.deconstruct()[:2] for f in model._meta.fields))
     return md5hex(stamp)
 
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -67,9 +67,7 @@ def stamp_fields(model):
     """
     Returns serialized description of model fields.
     """
-    stamp = str(sorted(
-        (f.name, f.attname, f.db_column or '', f.__class__.__name__)
-        for f in model._meta.fields))
+    stamp = str(sorted(f.deconstruct() for f in model._meta.fields))
     return md5hex(stamp)
 
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -68,7 +68,7 @@ def stamp_fields(model):
     Returns serialized description of model fields.
     """
     stamp = str(sorted(
-        (f.name, f.attname, f.db_column, f.__class__.__name__)
+        (f.name, f.attname, f.db_column or '', f.__class__.__name__)
         for f in model._meta.fields))
     return md5hex(stamp)
 


### PR DESCRIPTION
In `stamp_fields` utility function we create a stamp from the list of `(f.name, f.attname, f.db_column, f.__class__)` for all model fields returned from meta:

```python
stamp = str(sorted((f.name, f.attname, f.db_column, f.__class__) for f in model._meta.fields))
```

The last element is the actual class type of the field and not a class name. This will fail, as before being stringified the list is sorted, and the classes cannot be compared. We should use a class name instead.

Also, if `db_column` was not provided in model definition, `f.db_column` will be `None`, which is not comparable as well.

Practically, a model may have two fields with the same name and `attname` if one field was contributed to model as private. `model._meta.fields` return both local and private fields.

More details here: https://github.com/Suor/django-cacheops/pull/352